### PR TITLE
Pass attr_consuming_service_index to authentication request

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Installation
 
 ### Dependencies ###
 
- * python 2.7 // python 3.6
+ * python 3.6
  * [xmlsec](https://pypi.python.org/pypi/xmlsec) Python bindings for the XML Security Library.
  * [isodate](https://pypi.python.org/pypi/isodate) An ISO 8601 date/time/
  duration parser and formatter

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -460,10 +460,10 @@ class OneLogin_Saml2_Auth(object):
         return self._last_authn_contexts
 
     def _create_authn_request(
-        self, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None
+        self, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, attr_consuming_service_index=None
     ):
         authn_request = OneLogin_Saml2_Authn_Request(
-            self._settings, force_authn, is_passive, set_nameid_policy, name_id_value_req
+            self._settings, force_authn, is_passive, set_nameid_policy, name_id_value_req, attr_consuming_service_index
         )
         self._last_request = authn_request.get_xml()
         self._last_request_id = authn_request.get_id()
@@ -498,7 +498,7 @@ class OneLogin_Saml2_Auth(object):
 
         return url, parameters
 
-    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None):
+    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, attr_consuming_service_index=None):
         """
         Initiates the SSO process.
 
@@ -522,7 +522,8 @@ class OneLogin_Saml2_Auth(object):
         """
         authn_request = self._create_authn_request(
             force_authn=force_authn, is_passive=is_passive,
-            set_nameid_policy=set_nameid_policy, name_id_value_req=name_id_value_req
+            set_nameid_policy=set_nameid_policy, name_id_value_req=name_id_value_req,
+            attr_consuming_service_index=attr_consuming_service_index
         )
         self._last_request = authn_request.get_xml()
         self._last_request_id = authn_request.get_id()

--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -498,7 +498,15 @@ class OneLogin_Saml2_Auth(object):
 
         return url, parameters
 
-    def login(self, return_to=None, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, attr_consuming_service_index=None):
+    def login(
+            self,
+            return_to=None,
+            force_authn=False,
+            is_passive=False,
+            set_nameid_policy=True,
+            name_id_value_req=None,
+            attr_consuming_service_index=None
+    ):
         """
         Initiates the SSO process.
 
@@ -519,6 +527,9 @@ class OneLogin_Saml2_Auth(object):
 
         :returns: Redirection URL
         :rtype: string
+
+        :param attr_consuming_service_index: Optional argument. Indicates the AttributeConsumingServiceIndex attribute
+        :type attr_consuming_service_index: string
         """
         authn_request = self._create_authn_request(
             force_authn=force_authn, is_passive=is_passive,

--- a/src/onelogin/saml2/authn_request.py
+++ b/src/onelogin/saml2/authn_request.py
@@ -22,7 +22,7 @@ class OneLogin_Saml2_Authn_Request(object):
 
     """
 
-    def __init__(self, settings, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None):
+    def __init__(self, settings, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, attr_consuming_service_index=None):
         """
         Constructs the AuthnRequest object.
 
@@ -106,9 +106,9 @@ class OneLogin_Saml2_Authn_Request(object):
                     requested_authn_context_str += '<saml:AuthnContextClassRef>%s</saml:AuthnContextClassRef>' % authn_context
                 requested_authn_context_str += '    </samlp:RequestedAuthnContext>'
 
-        attr_consuming_service_str = ''
-        if 'attributeConsumingService' in sp_data and sp_data['attributeConsumingService']:
-            attr_consuming_service_str = "\n    AttributeConsumingServiceIndex=\"%s\"" % sp_data['attributeConsumingService'].get('index', '1')
+        attr_consuming_service_str = ""
+        if attr_consuming_service_index:
+            attr_consuming_service_str = "\n    AttributeConsumingServiceIndex=\"%s\"" % attr_consuming_service_index
 
         request = OneLogin_Saml2_Templates.AUTHN_REQUEST % \
             {

--- a/src/onelogin/saml2/authn_request.py
+++ b/src/onelogin/saml2/authn_request.py
@@ -22,7 +22,15 @@ class OneLogin_Saml2_Authn_Request(object):
 
     """
 
-    def __init__(self, settings, force_authn=False, is_passive=False, set_nameid_policy=True, name_id_value_req=None, attr_consuming_service_index=None):
+    def __init__(
+            self,
+            settings,
+            force_authn=False,
+            is_passive=False,
+            set_nameid_policy=True,
+            name_id_value_req=None,
+            attr_consuming_service_index=None
+    ):
         """
         Constructs the AuthnRequest object.
 
@@ -40,6 +48,9 @@ class OneLogin_Saml2_Authn_Request(object):
 
         :param name_id_value_req: Optional argument. Indicates to the IdP the subject that should be authenticated
         :type name_id_value_req: string
+
+        :param attr_consuming_service_index: Optional argument. Indicates the AttributeConsumingServiceIndex attribute
+        :type attr_consuming_service_index: string
         """
         self._settings = settings
 

--- a/tests/src/OneLogin/saml2_tests/authn_request_test.py
+++ b/tests/src/OneLogin/saml2_tests/authn_request_test.py
@@ -356,7 +356,7 @@ class OneLogin_Saml2_Authn_Request_Test(unittest.TestCase):
         saml_settings = self.loadSettingsJSON()
         settings = OneLogin_Saml2_Settings(saml_settings)
 
-        authn_request = OneLogin_Saml2_Authn_Request(settings)
+        authn_request = OneLogin_Saml2_Authn_Request(settings=settings)
         authn_request_encoded = authn_request.get_request()
         inflated = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(authn_request_encoded))
 
@@ -365,7 +365,7 @@ class OneLogin_Saml2_Authn_Request_Test(unittest.TestCase):
         saml_settings = self.loadSettingsJSON('settings4.json')
         settings = OneLogin_Saml2_Settings(saml_settings)
 
-        authn_request = OneLogin_Saml2_Authn_Request(settings)
+        authn_request = OneLogin_Saml2_Authn_Request(settings=settings, attr_consuming_service_index="1")
         authn_request_encoded = authn_request.get_request()
         inflated = compat.to_string(OneLogin_Saml2_Utils.decode_base64_and_inflate(authn_request_encoded))
 


### PR DESCRIPTION
This makes it possible to specify which `attr_consuming_service_index` should be used. It is necessary if one has an environment with multiple services available (like, for example, eIDAS and eHerkenning). The `attr_consuming_service_index` is sent in the authentication request to specify if it has to be a eHerkenning or a eIDAS flow.