### PR TITLE
Missing keyname in metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'xmlsec>=1.0.5',
         'defusedxml>=0.5.0',
         'requests>=2.24.0',
+        'pyOpenSSL>=19.1.0',
     ],
     dependency_links=['http://github.com/mehcode/python-xmlsec/tarball/master'],
     extras_require={

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -272,17 +272,27 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
         metadata_without_descriptors = OneLogin_Saml2_Metadata.add_x509_key_descriptors(metadata, None)
         self.assertNotIn('<md:KeyDescriptor use="signing"', metadata_without_descriptors)
         self.assertNotIn('<md:KeyDescriptor use="encryption"', metadata_without_descriptors)
+        self.assertNotIn('<md:KeyDescriptor>', metadata_without_descriptors)
 
         metadata_without_descriptors = OneLogin_Saml2_Metadata.add_x509_key_descriptors(metadata, '')
         self.assertNotIn('<md:KeyDescriptor use="signing"', metadata_without_descriptors)
         self.assertNotIn('<md:KeyDescriptor use="encryption"', metadata_without_descriptors)
+        self.assertNotIn('<md:KeyDescriptor>', metadata_without_descriptors)
 
         cert_path = settings.get_cert_path()
         cert = self.file_contents(join(cert_path, 'sp.crt'))
 
-        metadata_with_descriptors = compat.to_string(OneLogin_Saml2_Metadata.add_x509_key_descriptors(metadata, cert))
-        self.assertIn('<md:KeyDescriptor use="signing"', metadata_with_descriptors)
-        self.assertIn('<md:KeyDescriptor use="encryption"', metadata_with_descriptors)
+        metadata_with_descriptor = compat.to_string(OneLogin_Saml2_Metadata.add_x509_key_descriptors(metadata, cert))
+        self.assertNotIn('<md:KeyDescriptor use="signing"', metadata_with_descriptor)
+        self.assertNotIn('<md:KeyDescriptor use="encryption"', metadata_with_descriptor)
+        self.assertIn('<md:KeyDescriptor>', metadata_with_descriptor)
+
+        metadata_with_descriptor = compat.to_string(
+            OneLogin_Saml2_Metadata.add_x509_key_descriptors(metadata, cert, add_encryption=False)
+        )
+        self.assertIn('<md:KeyDescriptor use="signing"', metadata_with_descriptor)
+        self.assertNotIn('<md:KeyDescriptor use="encryption"', metadata_with_descriptor)
+        self.assertNotIn('<md:KeyDescriptor>', metadata_with_descriptor)
 
         with self.assertRaises(Exception) as context:
             OneLogin_Saml2_Metadata.add_x509_key_descriptors('', cert)

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -513,9 +513,9 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         settings_info['security']['wantAssertionsEncrypted'] = True
         settings = OneLogin_Saml2_Settings(settings_info)
         metadata = compat.to_string(settings.get_sp_metadata())
-        self.assertEqual(2, metadata.count('<md:KeyDescriptor'))
-        self.assertEqual(1, metadata.count('<md:KeyDescriptor use="signing"'))
-        self.assertEqual(1, metadata.count('<md:KeyDescriptor use="encryption"'))
+        self.assertEqual(1, metadata.count('<md:KeyDescriptor>'))
+        self.assertEqual(0, metadata.count('<md:KeyDescriptor use="signing"'))
+        self.assertEqual(0, metadata.count('<md:KeyDescriptor use="encryption"'))
 
     def testGetSPMetadataWithx509certNew(self):
         """
@@ -529,6 +529,9 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         metadata = compat.to_string(settings.get_sp_metadata())
         self.assertNotEqual(len(metadata), 0)
         self.assertIn('<md:SPSSODescriptor', metadata)
+        # Response has no Signature, but contains 2 Key descriptors in the SPSSODescriptor element, because one is with
+        # the old certificate and the other has the new certificate (used for rollover period before replacing a
+        # certificate)
         self.assertEqual(2, metadata.count('<md:KeyDescriptor'))
         self.assertEqual(2, metadata.count('<md:KeyDescriptor use="signing"'))
         self.assertEqual(0, metadata.count('<md:KeyDescriptor use="encryption"'))
@@ -537,9 +540,10 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         settings_info['security']['wantAssertionsEncrypted'] = False
         settings = OneLogin_Saml2_Settings(settings_info)
         metadata = compat.to_string(settings.get_sp_metadata())
-        self.assertEqual(4, metadata.count('<md:KeyDescriptor'))
-        self.assertEqual(2, metadata.count('<md:KeyDescriptor use="signing"'))
-        self.assertEqual(2, metadata.count('<md:KeyDescriptor use="encryption"'))
+        # Now the certificates are used for both signing/encrypting, so the @use attribute is not needed
+        self.assertEqual(2, metadata.count('<md:KeyDescriptor>'))
+        self.assertEqual(0, metadata.count('<md:KeyDescriptor use="signing"'))
+        self.assertEqual(0, metadata.count('<md:KeyDescriptor use="encryption"'))
 
     def testGetSPMetadataSigned(self):
         """


### PR DESCRIPTION
Related to Taiga issue 15

Details from comments on Metadata:
- De ‘KeyInfo’ binnen de ‘KeyDescriptor’ van de ‘SPSSODescriptor’ moet een KeyName-element bevatten met al waarde de tumbprint van het gebruikte certificaat, bijvoorbeeld: <ds:KeyName>43005cb5518b950cbc6664945cec888debc594a0</ds:KeyName>;
- Als er 1 certificaat is opgenomen, welke voor signing en encryptie wordt gebruikt, daardoor dien je de ‘use="signing"’ weg te laten (alternatief is om het certificaat dubbel op te nemen en dan bij de ene ‘use="signing"’ en bij de nadere ‘use="encryption”’ te zetten");