### PR TITLE
Changes to AttributeConsumingService

### DIFF
--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -39,11 +39,12 @@ class OneLogin_Saml2_Metadata(object):
     @staticmethod
     def make_attribute_consuming_services(service_provider: dict) -> str:
         str_attribute_consuming_service = ''
-        if 'attributeConsumingService' not in service_provider:
+
+        attribute_consuming_services = service_provider.get('attributeConsumingService') or service_provider.get('attributeConsumingServices')
+        if not attribute_consuming_services:
             return str_attribute_consuming_service
 
         # Compatibility with older versions: attributeConsumingService was just a dictionary
-        attribute_consuming_services = service_provider['attributeConsumingService']
         if isinstance(attribute_consuming_services, dict):
             attribute_consuming_services = [attribute_consuming_services]
 
@@ -53,8 +54,11 @@ class OneLogin_Saml2_Metadata(object):
 
             attr_cs_desc_str = ''
             if "serviceDescription" in attribute_consuming_service:
-                attr_cs_desc_str = """            <md:ServiceDescription xml:lang="en">%s</md:ServiceDescription>
-""" % attribute_consuming_service['serviceDescription']
+                attr_cs_desc_str = """            <md:ServiceDescription xml:lang="%(lang)s">%(description)s</md:ServiceDescription>
+""" % {
+                    "lang": attribute_consuming_service.get("language", "en"),
+                    "description": attribute_consuming_service['serviceDescription']
+                }
 
             requested_attribute_data = []
             if 'requestedAttributes' in attribute_consuming_service:
@@ -94,11 +98,12 @@ class OneLogin_Saml2_Metadata(object):
                     requested_attribute_data.append(requested_attribute)
 
             str_attribute_consuming_service += """        <md:AttributeConsumingService index="%(attribute_consuming_service_index)s">
-            <md:ServiceName xml:lang="en">%(service_name)s</md:ServiceName>
+            <md:ServiceName xml:lang="%(lang)s">%(service_name)s</md:ServiceName>
 %(attr_cs_desc)s%(requested_attribute_str)s
         </md:AttributeConsumingService>
 """ % \
                                                {
+                                                   'lang': attribute_consuming_service.get("language", "en"),
                                                    'service_name': attribute_consuming_service.get('serviceName', ''),
                                                    'attr_cs_desc': attr_cs_desc_str,
                                                    'attribute_consuming_service_index': attribute_consuming_service.get(

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -440,8 +440,8 @@ class OneLogin_Saml2_Settings(object):
                 elif not validate_url(sp['assertionConsumerService']['url'], allow_single_domain_urls):
                     errors.append('sp_acs_url_invalid')
 
-                if sp.get('attributeConsumingService'):
-                    attribute_consuming_services = sp['attributeConsumingService']
+                attribute_consuming_services = sp.get('attributeConsumingService') or sp.get('attributeConsumingServices')
+                if attribute_consuming_services:
                     # Compatibility with older versions: attributeConsumingService was only a dict
                     if isinstance(attribute_consuming_services, dict):
                         attribute_consuming_services = [attribute_consuming_services]

--- a/tests/settings/settings12.json
+++ b/tests/settings/settings12.json
@@ -7,7 +7,7 @@
         "assertionConsumerService": {
             "url": "http://pytoolkit.com:8000/?acs"
         },
-        "attributeConsumingService": [
+        "attributeConsumingServices": [
             {
                 "isDefault": false,
                 "serviceName": "Test Service 1",
@@ -25,7 +25,8 @@
                         "friendlyName": "uid",
                         "isRequired": false
                     }
-                ]
+                ],
+                "language": "nl"
           },
           {
               "isDefault": false,

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -199,8 +199,8 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
             organization
         )
         self.assertIn("""        <md:AttributeConsumingService index="9000">
-            <md:ServiceName xml:lang="en">Test Service 1</md:ServiceName>
-            <md:ServiceDescription xml:lang="en">Test Service 1</md:ServiceDescription>
+            <md:ServiceName xml:lang="nl">Test Service 1</md:ServiceName>
+            <md:ServiceDescription xml:lang="nl">Test Service 1</md:ServiceDescription>
             <md:RequestedAttribute Name="userType" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
                 <saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">userType</saml:AttributeValue>
                 <saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">admin</saml:AttributeValue>


### PR DESCRIPTION
**Changes**

1. In the metadata, the `AttributeConsumingService` element, there needs to be at least one `RequestedAttribute` element with `Name` attribute equal to the ServiceID. I had accidentally used the EntityID.
2. In the metadata, the elements `ServiceName` and `ServiceDescription` have a language attribute. This was hardcoded to "en", but KPN asked to change it to "nl".

=> While working on this, I noticed that there is an issue with the "RequestedAttribute" elements: they appear both in the metadata and the service catalogue, but they shouldn't contain the same information (they have different namespaces in the xml!). This means that generating the service catalog is for now broken. (Taiga issue 17)