### PR TITLE
:sparkles: add algorithm as optional input parameter for auth.logout

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -559,7 +559,7 @@ class OneLogin_Saml2_Auth(object):
             self.add_request_signature(parameters, security['signatureAlgorithm'])
         return self.redirect_to(self.get_sso_url(), parameters)
 
-    def logout(self, return_to=None, name_id=None, session_index=None, nq=None, name_id_format=None, spnq=None):
+    def logout(self, return_to=None, name_id=None, session_index=None, nq=None, name_id_format=None, spnq=None, sign_algorithm=None):
         """
         Initiates the SLO process.
 
@@ -579,6 +579,9 @@ class OneLogin_Saml2_Auth(object):
         :type: string
 
         :param spnq: SP Name Qualifier
+        :type: string
+
+        :param sign_algorithm: Algorithm to sign a query string. If empty 'security.signatureAlgorithm' is used
         :type: string
 
         :returns: Redirection URL
@@ -615,7 +618,8 @@ class OneLogin_Saml2_Auth(object):
 
         security = self._settings.get_security_data()
         if security.get('logoutRequestSigned', False):
-            self.add_request_signature(parameters, security['signatureAlgorithm'])
+            algorithm = sign_algorithm or security['signatureAlgorithm']
+            self.add_request_signature(parameters, algorithm)
         return self.redirect_to(slo_url, parameters)
 
     def get_sso_url(self):

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -870,6 +870,28 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         self.assertIn(return_to, parsed_query['RelayState'])
         self.assertIn(OneLogin_Saml2_Constants.RSA_SHA256, parsed_query['SigAlg'])
 
+    def testLogoutSignedWithSelectedAlgorithm(self):
+        """
+        Tests the logout method of the OneLogin_Saml2_Auth class
+        Case Logout signed with selected algorithm. A logout Request signed in
+        the assertion is built and redirect executed
+        """
+        settings_info = self.loadSettingsJSON()
+        settings_info['security']['logoutRequestSigned'] = True
+        auth = OneLogin_Saml2_Auth(self.get_request(), old_settings=settings_info)
+        return_to = u'http://example.com/returnto'
+
+        target_url = auth.logout(return_to, sign_algorithm=OneLogin_Saml2_Constants.RSA_SHA1)
+        parsed_query = parse_qs(urlparse(target_url)[4])
+        slo_url = settings_info['idp']['singleLogoutService']['url']
+        self.assertIn(slo_url, target_url)
+        self.assertIn('SAMLRequest', parsed_query)
+        self.assertIn('RelayState', parsed_query)
+        self.assertIn('SigAlg', parsed_query)
+        self.assertIn('Signature', parsed_query)
+        self.assertIn(return_to, parsed_query['RelayState'])
+        self.assertIn(OneLogin_Saml2_Constants.RSA_SHA1, parsed_query['SigAlg'])
+
     def testLogoutNoSLO(self):
         """
         Tests the logout method of the OneLogin_Saml2_Auth class


### PR DESCRIPTION
For now `security.signatureAlgorithm` is used for both generating SP metadata and signing Logout request (with HTTP-redirect binding)

But according to SAML and Digid documentation:
* request HTTP-redirect binding should be signed with DSAwithSHA1 or RSAwithSHA1 algorithm (page 18 of https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf and page 30 of https://www.logius.nl/sites/default/files/public/bestanden/diensten/DigiD/Koppelvlakspecificatie-SAML-DigiD.pdf)
* signing metadata can be processed with other algorithms

I'd like to separate them 